### PR TITLE
deps(infra): consolidate dependency updates

### DIFF
--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -48,7 +48,7 @@ jobs:
       MIKRUS_DOCKER_COMPOSE_DIR: ${{ vars.MIKRUS_DOCKER_COMPOSE_DIR }}
       SSHPASS: ${{ secrets.MIKRUS_PASSWORD }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/set-restorio-app-version
         with:

--- a/.github/workflows/deploy-static-frontend.yml
+++ b/.github/workflows/deploy-static-frontend.yml
@@ -48,7 +48,7 @@ jobs:
       MIKRUS_DOCKER_COMPOSE_DIR: ${{ vars.MIKRUS_DOCKER_COMPOSE_DIR }}
       SSHPASS: ${{ secrets.MIKRUS_PASSWORD }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/set-restorio-app-version
         with:

--- a/.github/workflows/deploy-vinext-frontend.yml
+++ b/.github/workflows/deploy-vinext-frontend.yml
@@ -45,7 +45,7 @@ jobs:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/set-restorio-app-version
         with:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -24,12 +24,12 @@ jobs:
       packages-and-apps: ${{ steps.filter.outputs.packages-and-apps }}
       api: ${{ steps.filter.outputs.api }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Path filter
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             packages-and-apps:
@@ -65,7 +65,7 @@ jobs:
             kind: app
             package: '@restorio/waiter-panel'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/setup-bun
 
@@ -110,7 +110,7 @@ jobs:
             cp "$APP_DIR/coverage/coverage-summary.json" coverage-artifacts/coverage-${{ matrix.target }}.json
           fi
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: success()
         with:
           name: coverage-${{ matrix.target }}
@@ -124,7 +124,7 @@ jobs:
       - typescript-matrix
     if: needs.detect-changes.outputs.packages-and-apps == 'true' && needs.typescript-matrix.result == 'success'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/setup-bun
 
@@ -146,7 +146,7 @@ jobs:
           bun run coverage:report
 
       - name: Comment coverage on PR
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           path: coverage-summary.md
           header: typescript-coverage
@@ -157,13 +157,13 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.api == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Validate Python Code
         uses: ./.github/actions/pr-validate/python
 
       - name: Comment coverage on PR
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           path: app/api/coverage-summary.md
           header: python-api-coverage

--- a/app/api/Dockerfile
+++ b/app/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -36,7 +36,7 @@ services:
       '
 
   postgres:
-    image: postgis/postgis:16-3.5-alpine
+    image: postgis/postgis:17-3.5-alpine
     container_name: restorio-postgres-dev
     environment:
       - POSTGRES_DB=${POSTGRES_DB:-restorio}
@@ -54,7 +54,7 @@ services:
       start_period: 20s
 
   mongo:
-    image: mongo:7
+    image: mongo:8
     container_name: restorio-mongo-dev
     environment:
       - MONGO_INITDB_ROOT_USERNAME=${MONGODB_USERNAME:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       start_period: 60s
 
   postgres:
-    image: postgis/postgis:16-3.5-alpine
+    image: postgis/postgis:17-3.5-alpine
     container_name: restorio-postgres
     environment:
       - POSTGRES_DB=${POSTGRES_DB:-restorio}
@@ -88,7 +88,7 @@ services:
       start_period: 60s
 
   mongo:
-    image: mongo:7
+    image: mongo:8
     container_name: restorio-mongo
     environment:
       - MONGO_INITDB_ROOT_USERNAME=${MONGODB_USERNAME:-restorio}


### PR DESCRIPTION
## What changed

- consolidates Dependabot PRs #251, #252, #253, #255, #256, #258, and #259
- upgrades GitHub Actions references for checkout, artifact upload, path filtering, and sticky PR comments
- upgrades the API container base image from Python 3.12 to Python 3.14
- upgrades Compose services from MongoDB 7 to 8 and PostgreSQL 16 to 17
- preserves PostGIS 3.5 instead of accepting the unintended Dependabot downgrade to 3.4

## Why

The individual Dependabot branches overlap in the PR validation workflow and should be reviewed as one coherent infrastructure dependency set.

## Validation

- all referenced GitHub Action refs exist
- `docker compose config` passes for production and development Compose files
- all referenced container image tags exist
- the API Docker image builds successfully with Python 3.14 and installs all project dependencies

## Deployment warning

MongoDB 7 to 8 and PostgreSQL 16 to 17 are major database upgrades. Do not deploy this branch against existing persistent production volumes until the database migration, backup, compatibility validation, and rollback procedure has been completed.
